### PR TITLE
Fixing dimension and multiplayer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Versionfiles"]
 	path = Versionfiles
-	url = git@github.com:ModProg/Versionfiles.git
+	url = https://github.com/ModProg/Versionfiles.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Versionfiles"]
 	path = Versionfiles
-	url = https://github.com/gbl/Versionfiles.git
+	url = git@github.com:ModProg/Versionfiles.git

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     modCompile  "me.shedaniel.cloth:config-2:${Versions['clothconfig_version']}"
     modCompile  "me.sargunvohra.mcmods:autoconfig1u:${Versions['autoconfig_version']}"
 
-    include	    "me.shedaniel.cloth:config-2:${Versions['clothconfig_version']}"
+    include     "me.shedaniel.cloth:config-2:${Versions['clothconfig_version']}"
     include     "me.sargunvohra.mcmods:autoconfig1u:${Versions['autoconfig_version']}"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "fabric-loom" version "0.4-SNAPSHOT"
+    id 'fabric-loom' version '0.4-SNAPSHOT'
 }
 
 repositories {
@@ -14,7 +14,7 @@ repositories {
     }
     
     maven {
-        url = "https://hub.spigotmc.org/nexus/content/repositories/snapshots/"
+        url = 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/'
     }
     
     maven {
@@ -50,13 +50,8 @@ processResources {
 }
 
 dependencies {
-    modCompile ("org.bukkit:bukkit:1.15.2-R0.1-SNAPSHOT") {
-        // This is to fix the error:
-        // com.google.*:*:* has more than one client module definitions
-        // in gradle > 4
-        exclude group: "com.google.guava", module: "guava"
-        exclude group: "com.google.code.gson", module: "gson"
-    }
+    
+    modCompile  'org.bukkit:bukkit:1.15.2-R0.1-SNAPSHOT'
 
     minecraft   "com.mojang:minecraft:${Versions['minecraft_version']}"
     mappings    "net.fabricmc:yarn:${Versions['yarn_mappings']}:v2"
@@ -75,7 +70,7 @@ dependencies {
 // if it is present.
 // If you remove this task, sources will not be generated.
 task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = "sources"
+    classifier = 'sources'
     from sourceSets.main.allSource
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.4-SNAPSHOT'
+    id "fabric-loom" version "0.4-SNAPSHOT"
 }
 
 repositories {
@@ -14,7 +14,7 @@ repositories {
     }
     
     maven {
-        url = 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/'
+        url = "https://hub.spigotmc.org/nexus/content/repositories/snapshots/"
     }
     
     maven {
@@ -50,8 +50,13 @@ processResources {
 }
 
 dependencies {
-    
-    modCompile  'org.bukkit:bukkit:1.15.2-R0.1-SNAPSHOT'
+    modCompile ("org.bukkit:bukkit:1.15.2-R0.1-SNAPSHOT") {
+        // This is to fix the error:
+        // com.google.*:*:* has more than one client module definitions
+        // in gradle > 4
+        exclude group: "com.google.guava", module: "guava"
+        exclude group: "com.google.code.gson", module: "gson"
+    }
 
     minecraft   "com.mojang:minecraft:${Versions['minecraft_version']}"
     mappings    "net.fabricmc:yarn:${Versions['yarn_mappings']}:v2"
@@ -70,7 +75,7 @@ dependencies {
 // if it is present.
 // If you remove this task, sources will not be generated.
 task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
+    classifier = "sources"
     from sourceSets.main.allSource
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 plugins {
-	id 'fabric-loom' version '0.4-SNAPSHOT'
+    id 'fabric-loom' version '0.4-SNAPSHOT'
 }
 
 repositories {
-	maven {
-		url = "https://maven.fabricmc.net/"
-	}
-	maven {
-		url = "https://minecraft.guntram.de/maven/"
-	}
+    maven {
+        url = "https://maven.fabricmc.net/"
+    }
+    maven {
+        url = "https://minecraft.guntram.de/maven/"
+    }
     maven {
         url = "file:///tmp/mymavenrepo/"
     }
@@ -18,8 +18,8 @@ repositories {
     }
     
     maven {
-		url = "https://jitpack.io"
-	}
+        url = "https://jitpack.io"
+    }
 }
 
 sourceCompatibility = 1.8
@@ -38,38 +38,42 @@ minecraft {
 }
 
 processResources {
-	inputs.property "version", project.version
+    inputs.property "version", project.version
 
     from(sourceSets.main.resources.srcDirs) {
-		include "fabric.mod.json"
-		expand "version": project.version
-	}
-	from(sourceSets.main.resources.srcDirs) {
-		exclude "fabric.mod.json"
-	}
+        include "fabric.mod.json"
+        expand "version": project.version
+    }
+    from(sourceSets.main.resources.srcDirs) {
+        exclude "fabric.mod.json"
+    }
 }
 
 dependencies {
     
-    modCompile 'org.bukkit:bukkit:1.15.2-R0.1-SNAPSHOT'
+    modCompile  'org.bukkit:bukkit:1.15.2-R0.1-SNAPSHOT'
 
-    minecraft  "com.mojang:minecraft:${Versions['minecraft_version']}"
-    mappings   "net.fabricmc:yarn:${Versions['yarn_mappings']}:v2"
-    modCompile "net.fabricmc:fabric-loader:${Versions['loader_version']}"
-    modCompile "net.fabricmc.fabric-api:fabric-api:${Versions['fabric_version']}"
-    modCompile "io.github.prospector:modmenu:${Versions['modmenu_version']}"
-    modCompile "de.guntram.mcmod:GBfabrictools:${Versions['gbfabrictools_version']}"
-    include    "de.guntram.mcmod:GBfabrictools:${Versions['gbfabrictools_version']}"
+    minecraft   "com.mojang:minecraft:${Versions['minecraft_version']}"
+    mappings    "net.fabricmc:yarn:${Versions['yarn_mappings']}:v2"
+    modCompile  "net.fabricmc:fabric-loader:${Versions['loader_version']}"
+    modCompile  "net.fabricmc.fabric-api:fabric-api:${Versions['fabric_version']}"
+
+    modCompile  "io.github.prospector:modmenu:${Versions['modmenu_version']}"
+    modCompile  "me.shedaniel.cloth:config-2:${Versions['clothconfig_version']}"
+    modCompile  "me.sargunvohra.mcmods:autoconfig1u:${Versions['autoconfig_version']}"
+
+    include	    "me.shedaniel.cloth:config-2:${Versions['clothconfig_version']}"
+    include     "me.sargunvohra.mcmods:autoconfig1u:${Versions['autoconfig_version']}"
 }
 
 // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
 // if it is present.
 // If you remove this task, sources will not be generated.
 task sourcesJar(type: Jar, dependsOn: classes) {
-	classifier = 'sources'
-	from sourceSets.main.allSource
+    classifier = 'sources'
+    from sourceSets.main.allSource
 }
 
 jar {
-	from "LICENSE"
+    from "LICENSE"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,8 +2,8 @@ pluginManagement {
     repositories {
         jcenter()
         maven {
-            name = 'Fabric'
-            url = 'https://maven.fabricmc.net/'
+            name = "Fabric"
+            url = "https://maven.fabricmc.net/"
         }
         gradlePluginPortal()
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,8 +2,8 @@ pluginManagement {
     repositories {
         jcenter()
         maven {
-            name = "Fabric"
-            url = "https://maven.fabricmc.net/"
+            name = 'Fabric'
+            url = 'https://maven.fabricmc.net/'
         }
         gradlePluginPortal()
     }

--- a/src/main/java/win/baruna/blockmeter/BlockMeterClient.java
+++ b/src/main/java/win/baruna/blockmeter/BlockMeterClient.java
@@ -29,7 +29,6 @@ import net.minecraft.network.PacketByteBuf;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.ActionResult;
-import net.minecraft.util.DyeColor;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
@@ -102,6 +101,18 @@ public class BlockMeterClient implements ClientModInitializer {
         sendBoxList(); // to make the server send other user's boxes
     }
 
+    /**
+     * Returns the currently active box
+     * 
+     * @return currently open box or null if none
+     */
+    public ClientMeasureBox currentBox() {
+        final ClientMeasureBox lastBox = this.boxes.get(this.boxes.size() - 1);
+        if (!lastBox.isFinished())
+            return lastBox;
+        return null;
+    }
+
     @Override
     public void onInitializeClient() {
         final KeyBinding keyBinding = new KeyBinding("key.blockmeter.assign", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_M, "category.blockmeter.key");
@@ -151,9 +162,8 @@ public class BlockMeterClient implements ClientModInitializer {
             }
 
             if (this.active && this.boxes.size() > 0) {
-                final ClientMeasureBox lastBox = this.boxes.get(this.boxes.size() - 1);
-                if (!lastBox.isFinished()) {
-                    lastBox.color = DyeColor.byId(ClientMeasureBox.colorIndex);
+                final ClientMeasureBox lastBox = currentBox();
+                if (lastBox != null) {
                     final HitResult rayHit = e.player.rayTrace((double) e.interactionManager.getReachDistance(), 1.0f, false);
                     if (rayHit.getType() == HitResult.Type.BLOCK) {
                         final BlockHitResult blockHitResult = (BlockHitResult) rayHit;

--- a/src/main/java/win/baruna/blockmeter/BlockMeterClient.java
+++ b/src/main/java/win/baruna/blockmeter/BlockMeterClient.java
@@ -110,7 +110,7 @@ public class BlockMeterClient implements ClientModInitializer {
         KeyBindingHelper.registerKeyBinding(keyBindingMenu);
 
         AutoConfig.register(ModConfig.class, Toml4jConfigSerializer::new);
-
+        ModConfig config = AutoConfig.getConfigHolder(ModConfig.class).getConfig();
 
         ClientSidePacketRegistry.INSTANCE.register(BlockMeter.S2CPacketIdentifier, this::receiveBoxList);
         ClientTickEvents.START_CLIENT_TICK.register(e -> {
@@ -122,11 +122,17 @@ public class BlockMeterClient implements ClientModInitializer {
                             sendBoxList();
                         }
                         e.player.sendMessage(new TranslatableText("blockmeter.clearlast"), true);
+                    } else if (Screen.hasControlDown()) {
+                        this.boxes.clear();
+                        sendBoxList();
+                        e.player.sendMessage(new TranslatableText("blockmeter.clearall"), true);
                     } else {
                         this.active = false;
                         e.player.sendMessage(new TranslatableText("blockmeter.toggle.off", new Object[0]), true);
-                        this.boxes.clear();
-                        sendBoxList();
+                        if (config.deleteBoxesOnDisable) {
+                            this.boxes.clear();
+                            sendBoxList();
+                        }
                     }
                 } else {
                     active = true;

--- a/src/main/java/win/baruna/blockmeter/BlockMeterClient.java
+++ b/src/main/java/win/baruna/blockmeter/BlockMeterClient.java
@@ -105,9 +105,11 @@ public class BlockMeterClient implements ClientModInitializer {
      * @return currently open box or null if none
      */
     public ClientMeasureBox currentBox() {
-        final ClientMeasureBox lastBox = this.boxes.get(this.boxes.size() - 1);
-        if (!lastBox.isFinished())
-            return lastBox;
+        if(boxes.size()>0){
+            final ClientMeasureBox lastBox = boxes.get(boxes.size() - 1);
+            if (!lastBox.isFinished())
+                return lastBox;
+        }
         return null;
     }
 

--- a/src/main/java/win/baruna/blockmeter/BlockMeterClient.java
+++ b/src/main/java/win/baruna/blockmeter/BlockMeterClient.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import org.lwjgl.glfw.GLFW;
 
 import io.netty.buffer.Unpooled;
+import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.sargunvohra.mcmods.autoconfig1u.serializer.Toml4jConfigSerializer;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
@@ -106,6 +108,7 @@ public class BlockMeterClient implements ClientModInitializer {
         final KeyBinding keyBindingMenu = new KeyBinding("key.blockmeter.menu", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_LEFT_ALT, "category.blockmeter.key");
         KeyBindingHelper.registerKeyBinding(keyBinding);
         KeyBindingHelper.registerKeyBinding(keyBindingMenu);
+        AutoConfig.register(ModConfig.class, Toml4jConfigSerializer::new);
 
         ClientSidePacketRegistry.INSTANCE.register(BlockMeter.S2CPacketIdentifier, this::receiveBoxList);
         ClientTickEvents.START_CLIENT_TICK.register(e -> {

--- a/src/main/java/win/baruna/blockmeter/BlockMeterClient.java
+++ b/src/main/java/win/baruna/blockmeter/BlockMeterClient.java
@@ -108,7 +108,9 @@ public class BlockMeterClient implements ClientModInitializer {
         final KeyBinding keyBindingMenu = new KeyBinding("key.blockmeter.menu", InputUtil.Type.KEYSYM, GLFW.GLFW_KEY_LEFT_ALT, "category.blockmeter.key");
         KeyBindingHelper.registerKeyBinding(keyBinding);
         KeyBindingHelper.registerKeyBinding(keyBindingMenu);
+
         AutoConfig.register(ModConfig.class, Toml4jConfigSerializer::new);
+
 
         ClientSidePacketRegistry.INSTANCE.register(BlockMeter.S2CPacketIdentifier, this::receiveBoxList);
         ClientTickEvents.START_CLIENT_TICK.register(e -> {

--- a/src/main/java/win/baruna/blockmeter/BlockMeterClient.java
+++ b/src/main/java/win/baruna/blockmeter/BlockMeterClient.java
@@ -250,16 +250,26 @@ public class BlockMeterClient implements ClientModInitializer {
         final ModConfig config = AutoConfig.getConfigHolder(ModConfig.class).getConfig();
 
         client.textRenderer.draw(stack, "XXX", -100, -100, 0); // MEH! but this seems to be needed to get the first background rectangle
-        if (config.showOtherUsersBoxes && otherUsersBoxes != null && otherUsersBoxes.size() > 0) {
-            this.otherUsersBoxes.forEach((playerText, boxList) -> {
-                boxList.forEach(box -> box.render(camera, stack, currentDimension, playerText));
-            });
-            this.boxes.forEach(box -> {
-                if (!box.isFinished())
-                    box.render(camera, stack, currentDimension);
-            });
-        } else if (this.active) {
-            this.boxes.forEach(box -> box.render(camera, stack, currentDimension));
-        }
+        if (this.active || config.showBoxesWhenDisabled)
+            if (config.showOtherUsersBoxes) {
+                if (otherUsersBoxes != null && otherUsersBoxes.size() > 0) {
+                    this.otherUsersBoxes.forEach((playerText, boxList) -> {
+                        boxList.forEach(box -> box.render(camera, stack, currentDimension, playerText));
+                    });
+                    this.boxes.forEach(box -> {
+                        if (!box.isFinished())
+                            box.render(camera, stack, currentDimension);
+                    });
+                }
+                if (!config.sendBoxes)
+                    this.boxes.forEach(box -> {
+                        if (box.isFinished())
+                            box.render(camera, stack, currentDimension, client.player.getDisplayName());
+                        else
+                            box.render(camera, stack, currentDimension);
+                    });
+            } else
+                this.boxes.forEach(box -> box.render(camera, stack, currentDimension));
+
     }
 }

--- a/src/main/java/win/baruna/blockmeter/ClientMeasureBox.java
+++ b/src/main/java/win/baruna/blockmeter/ClientMeasureBox.java
@@ -198,7 +198,7 @@ public class ClientMeasureBox extends MeasureBox {
         @SuppressWarnings("resource")
         final TextRenderer textRenderer = MinecraftClient.getInstance().textRenderer;
 
-        final LiteralText lengthString = new LiteralText(text);
+        final LiteralText literalText = new LiteralText(text);
 
         float size = 0.03f;
         final int constDist = 10;
@@ -214,7 +214,7 @@ public class ClientMeasureBox extends MeasureBox {
         stack.multiply(Vector3f.POSITIVE_Y.getDegreesQuaternion(180.0F - yaw));
         stack.multiply(Vector3f.POSITIVE_X.getDegreesQuaternion(-pitch));
         stack.scale(size, -size, 0.001f);
-        int width = textRenderer.getWidth(lengthString);
+        int width = textRenderer.getWidth(literalText);
         stack.translate((-width / 2), 0.0, 0.0);
         Matrix4f model = stack.peek().getModel();
         BufferBuilder buffer = Tessellator.getInstance().getBuffer();
@@ -228,14 +228,14 @@ public class ClientMeasureBox extends MeasureBox {
         Tessellator.getInstance().draw();
 
         VertexConsumerProvider.Immediate immediate = VertexConsumerProvider.immediate(buffer);
-        textRenderer.draw(lengthString, 0.0f, 0.0f,
+        textRenderer.draw(literalText, 0.0f, 0.0f,
                 this.color.getSignColor(),
                 false,                              // shadow
                 model,                              // matrix
                 immediate,                          // draw buffer
                 true,                               // seeThrough
                 0,                                  // backgroundColor => underlineColor,
-                0                                   // light
+                0                                  // light
         );
         immediate.draw();
 

--- a/src/main/java/win/baruna/blockmeter/ClientMeasureBox.java
+++ b/src/main/java/win/baruna/blockmeter/ClientMeasureBox.java
@@ -21,6 +21,7 @@ import net.minecraft.network.PacketByteBuf;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import net.minecraft.util.DyeColor;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.math.Matrix4f;
@@ -36,7 +37,7 @@ public class ClientMeasureBox extends MeasureBox {
         super();
     }
 
-    ClientMeasureBox(final BlockPos block, final String dimension) {
+    ClientMeasureBox(final BlockPos block, final Identifier dimension) {
         this.blockStart = block;
         this.blockEnd = block;
         this.dimension = dimension;
@@ -77,11 +78,11 @@ public class ClientMeasureBox extends MeasureBox {
 
     }
 
-    void render(Camera camera, MatrixStack stack, String currentDimension) {
+    void render(Camera camera, MatrixStack stack, Identifier currentDimension) {
         render(camera, stack, currentDimension, null);
     }
 
-    void render(final Camera camera, MatrixStack stack, final String currentDimension, Text playerName) {
+    void render(final Camera camera, MatrixStack stack, final Identifier currentDimension, Text playerName) {
         if (!(currentDimension.equals(this.dimension))) {
             return;
         }

--- a/src/main/java/win/baruna/blockmeter/ClientMeasureBox.java
+++ b/src/main/java/win/baruna/blockmeter/ClientMeasureBox.java
@@ -196,11 +196,11 @@ public class ClientMeasureBox extends MeasureBox {
         this.drawText(stack, lineZ.x, lineZ.y, lineZ.z, yaw, pitch, playerNameStr + String.valueOf(lengthZ), pos);
     }
 
-    private void drawText(MatrixStack stack, final double x, final double y, final double z, final float yaw, final float pitch, final String length, final Vec3d playerPos) {
+    private void drawText(MatrixStack stack, final double x, final double y, final double z, final float yaw, final float pitch, final String text, final Vec3d playerPos) {
         @SuppressWarnings("resource")
         final TextRenderer textRenderer = MinecraftClient.getInstance().textRenderer;
 
-        final LiteralText lengthString = new LiteralText(length);
+        final LiteralText lengthString = new LiteralText(text);
 
         float size = 0.03f;
         final int constDist = 10;

--- a/src/main/java/win/baruna/blockmeter/ClientMeasureBox.java
+++ b/src/main/java/win/baruna/blockmeter/ClientMeasureBox.java
@@ -1,12 +1,12 @@
 package win.baruna.blockmeter;
 
-import com.mojang.blaze3d.systems.RenderSystem;
-
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+
+import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.render.BufferBuilder;
@@ -98,7 +98,6 @@ public class ClientMeasureBox extends MeasureBox {
 
         final Tessellator tess = Tessellator.getInstance();
         final BufferBuilder buffer = tess.getBuffer();
-
         final float[] color = this.color.getColorComponents();
         final float r = color[0];
         final float g = color[1];
@@ -203,12 +202,12 @@ public class ClientMeasureBox extends MeasureBox {
         final LiteralText lengthString = new LiteralText(length);
 
         float size = 0.03f;
-        final int constDist=10;
+        final int constDist = 10;
 
         if (AutoConfig.getConfigHolder(ModConfig.class).getConfig().minimalLabelSize) {
             final float dist = (float) Math.sqrt((x - playerPos.x) * (x - playerPos.x) + (y - playerPos.y) * (y - playerPos.y) + (z - playerPos.z) * (z - playerPos.z));
-            if(dist > constDist)
-                size = dist * size/constDist;
+            if (dist > constDist)
+                size = dist * size / constDist;
         }
 
         stack.push();
@@ -300,5 +299,9 @@ public class ClientMeasureBox extends MeasureBox {
         boolean isVisible(Box line) {
             return true;
         }
+    }
+
+    public void setColor(DyeColor color) {
+        this.color = color;
     }
 }

--- a/src/main/java/win/baruna/blockmeter/ClientMeasureBox.java
+++ b/src/main/java/win/baruna/blockmeter/ClientMeasureBox.java
@@ -1,6 +1,9 @@
 package win.baruna.blockmeter;
 
 import com.mojang.blaze3d.systems.RenderSystem;
+
+import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -186,20 +189,27 @@ public class ClientMeasureBox extends MeasureBox {
 
         String playerNameStr = (playerName == null ? "" : playerName.getString() + " : ");
         if (ClientMeasureBox.innerDiagonal) {
-            this.drawText(stack, boxCenter.x, boxCenter.y, boxCenter.z, yaw, pitch, playerNameStr + String.format("%.2f", diagonalLength));
+            this.drawText(stack, boxCenter.x, boxCenter.y, boxCenter.z, yaw, pitch, playerNameStr + String.format("%.2f", diagonalLength), pos);
         }
-        this.drawText(stack, lineX.x, lineX.y, lineX.z, yaw, pitch, playerNameStr + String.valueOf(lengthX));
-        this.drawText(stack, lineY.x, lineY.y, lineY.z, yaw, pitch, playerNameStr + String.valueOf(lengthY));
-        this.drawText(stack, lineZ.x, lineZ.y, lineZ.z, yaw, pitch, playerNameStr + String.valueOf(lengthZ));
+        this.drawText(stack, lineX.x, lineX.y, lineX.z, yaw, pitch, playerNameStr + String.valueOf(lengthX), pos);
+        this.drawText(stack, lineY.x, lineY.y, lineY.z, yaw, pitch, playerNameStr + String.valueOf(lengthY), pos);
+        this.drawText(stack, lineZ.x, lineZ.y, lineZ.z, yaw, pitch, playerNameStr + String.valueOf(lengthZ), pos);
     }
 
-    private void drawText(MatrixStack stack, final double x, final double y, final double z, final float yaw, final float pitch, final String length) {
+    private void drawText(MatrixStack stack, final double x, final double y, final double z, final float yaw, final float pitch, final String length, final Vec3d playerPos) {
         @SuppressWarnings("resource")
         final TextRenderer textRenderer = MinecraftClient.getInstance().textRenderer;
 
         final LiteralText lengthString = new LiteralText(length);
 
-        final float size = 0.03f;
+        float size = 0.03f;
+        final int constDist=10;
+
+        if (AutoConfig.getConfigHolder(ModConfig.class).getConfig().consistentLabelSize) {
+            final float dist = (float) Math.sqrt((x - playerPos.x) * (x - playerPos.x) + (y - playerPos.y) * (y - playerPos.y) + (z - playerPos.z) * (z - playerPos.z));
+            if(dist > constDist)
+                size = dist * size/constDist;
+        }
 
         stack.push();
         stack.translate(x, y + 0.15, z);

--- a/src/main/java/win/baruna/blockmeter/ClientMeasureBox.java
+++ b/src/main/java/win/baruna/blockmeter/ClientMeasureBox.java
@@ -205,7 +205,7 @@ public class ClientMeasureBox extends MeasureBox {
         float size = 0.03f;
         final int constDist=10;
 
-        if (AutoConfig.getConfigHolder(ModConfig.class).getConfig().consistentLabelSize) {
+        if (AutoConfig.getConfigHolder(ModConfig.class).getConfig().minimalLabelSize) {
             final float dist = (float) Math.sqrt((x - playerPos.x) * (x - playerPos.x) + (y - playerPos.y) * (y - playerPos.y) + (z - playerPos.z) * (z - playerPos.z));
             if(dist > constDist)
                 size = dist * size/constDist;

--- a/src/main/java/win/baruna/blockmeter/ClientMeasureBox.java
+++ b/src/main/java/win/baruna/blockmeter/ClientMeasureBox.java
@@ -235,7 +235,7 @@ public class ClientMeasureBox extends MeasureBox {
                 immediate,                          // draw buffer
                 true,                               // seeThrough
                 0,                                  // backgroundColor => underlineColor,
-                0                                  // light
+                0                                   // light
         );
         immediate.draw();
 

--- a/src/main/java/win/baruna/blockmeter/MeasureBox.java
+++ b/src/main/java/win/baruna/blockmeter/MeasureBox.java
@@ -12,6 +12,8 @@ public class MeasureBox {
     Identifier dimension;
     DyeColor color;
     boolean finished;
+    int mode;
+    int orientation;
 
     MeasureBox() {};
 
@@ -21,6 +23,8 @@ public class MeasureBox {
         buf.writeIdentifier(dimension);
         buf.writeInt(color.getId());
         buf.writeBoolean(finished);
+        buf.writeInt(mode);
+        buf.writeInt(orientation);
     }
 
     public static MeasureBox fromPacketByteBuf(PacketByteBuf attachedData) {
@@ -35,6 +39,8 @@ public class MeasureBox {
         dimension = attachedData.readIdentifier();
         color = DyeColor.byId(attachedData.readInt());
         finished = attachedData.readBoolean();
+        mode = attachedData.readInt();
+        orientation = attachedData.readInt();
 
         if (Math.abs(blockStart.getX() - blockEnd.getX()) > 1024
                 || Math.abs(blockStart.getZ() - blockEnd.getZ()) > 1024

--- a/src/main/java/win/baruna/blockmeter/MeasureBox.java
+++ b/src/main/java/win/baruna/blockmeter/MeasureBox.java
@@ -2,13 +2,14 @@ package win.baruna.blockmeter;
 
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.util.DyeColor;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 
 public class MeasureBox {
 
     BlockPos blockStart;
     BlockPos blockEnd;
-    String dimension;
+    Identifier dimension;
     DyeColor color;
     boolean finished;
 
@@ -17,7 +18,7 @@ public class MeasureBox {
     public void writePacketBuf(PacketByteBuf buf) {
         buf.writeBlockPos(this.blockStart);
         buf.writeBlockPos(this.blockEnd);
-        buf.writeString(dimension);
+        buf.writeIdentifier(dimension);
         buf.writeInt(color.getId());
         buf.writeBoolean(finished);
     }
@@ -31,7 +32,7 @@ public class MeasureBox {
     void fillFromPacketByteBuf(PacketByteBuf attachedData) {
         blockStart = attachedData.readBlockPos();
         blockEnd = attachedData.readBlockPos();
-        dimension = attachedData.readString();
+        dimension = attachedData.readIdentifier();
         color = DyeColor.byId(attachedData.readInt());
         finished = attachedData.readBoolean();
 

--- a/src/main/java/win/baruna/blockmeter/ModConfig.java
+++ b/src/main/java/win/baruna/blockmeter/ModConfig.java
@@ -20,4 +20,6 @@ public class ModConfig implements ConfigData {
     public boolean innerDiagonal = false;
     @ConfigEntry.Gui.Excluded
     public boolean showOtherUsersBoxes = false;
+    @ConfigEntry.Gui.Excluded
+    public int colorIndex = 0;
 }

--- a/src/main/java/win/baruna/blockmeter/ModConfig.java
+++ b/src/main/java/win/baruna/blockmeter/ModConfig.java
@@ -2,11 +2,21 @@ package win.baruna.blockmeter;
 
 import me.sargunvohra.mcmods.autoconfig1u.ConfigData;
 import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
+import me.sargunvohra.mcmods.autoconfig1u.annotation.ConfigEntry;
 
 @Config(name = "blockmeter")
 public class ModConfig implements ConfigData {
-    boolean minimalLabelSize = false;
+    @ConfigEntry.Gui.Tooltip(count = 2)
+    public boolean minimalLabelSize = false;
+    @ConfigEntry.Gui.Tooltip(count = 2)
+    public boolean deleteBoxesOnDisable = true;
+    @ConfigEntry.Gui.Tooltip(count = 3)
+    public boolean sendBoxes = true;
 
-    boolean deleteBoxesOnDisable = true;
-
+    @ConfigEntry.Gui.Excluded
+    public boolean incrementColor = true;
+    @ConfigEntry.Gui.Excluded
+    public boolean innerDiagonal = false;
+    @ConfigEntry.Gui.Excluded
+    public boolean showOtherUsersBoxes = false;
 }

--- a/src/main/java/win/baruna/blockmeter/ModConfig.java
+++ b/src/main/java/win/baruna/blockmeter/ModConfig.java
@@ -7,4 +7,5 @@ import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
 public class ModConfig implements ConfigData {
     boolean minimalLabelSize = false;
     
+    boolean deleteBoxesOnDisable = true;
 }

--- a/src/main/java/win/baruna/blockmeter/ModConfig.java
+++ b/src/main/java/win/baruna/blockmeter/ModConfig.java
@@ -6,6 +6,7 @@ import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
 @Config(name = "blockmeter")
 public class ModConfig implements ConfigData {
     boolean minimalLabelSize = false;
-    
+
     boolean deleteBoxesOnDisable = true;
+
 }

--- a/src/main/java/win/baruna/blockmeter/ModConfig.java
+++ b/src/main/java/win/baruna/blockmeter/ModConfig.java
@@ -5,5 +5,6 @@ import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
 
 @Config(name = "blockmeter")
 public class ModConfig implements ConfigData {
-    boolean consistentLabelSize = false;
+    boolean minimalLabelSize = false;
+    
 }

--- a/src/main/java/win/baruna/blockmeter/ModConfig.java
+++ b/src/main/java/win/baruna/blockmeter/ModConfig.java
@@ -2,22 +2,8 @@ package win.baruna.blockmeter;
 
 import me.sargunvohra.mcmods.autoconfig1u.ConfigData;
 import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
-import me.sargunvohra.mcmods.autoconfig1u.annotation.ConfigEntry;
 
-@Config(name = "modid")
-public class ModConfig implements ConfigData{
-    boolean toggleA = true;
-    boolean toggleB = false;
-    
-    @ConfigEntry.Gui.CollapsibleObject
-    InnerStuff stuff = new InnerStuff();
-    
-    @ConfigEntry.Gui.Excluded
-    InnerStuff invisibleStuff = new InnerStuff();
-    
-    static class InnerStuff {
-        int a = 0;
-        int b = 1;
-    }
-    
+@Config(name = "blockmeter")
+public class ModConfig implements ConfigData {
+    boolean consistentLabelSize = false;
 }

--- a/src/main/java/win/baruna/blockmeter/ModConfig.java
+++ b/src/main/java/win/baruna/blockmeter/ModConfig.java
@@ -1,0 +1,23 @@
+package win.baruna.blockmeter;
+
+import me.sargunvohra.mcmods.autoconfig1u.ConfigData;
+import me.sargunvohra.mcmods.autoconfig1u.annotation.Config;
+import me.sargunvohra.mcmods.autoconfig1u.annotation.ConfigEntry;
+
+@Config(name = "modid")
+public class ModConfig implements ConfigData{
+    boolean toggleA = true;
+    boolean toggleB = false;
+    
+    @ConfigEntry.Gui.CollapsibleObject
+    InnerStuff stuff = new InnerStuff();
+    
+    @ConfigEntry.Gui.Excluded
+    InnerStuff invisibleStuff = new InnerStuff();
+    
+    static class InnerStuff {
+        int a = 0;
+        int b = 1;
+    }
+    
+}

--- a/src/main/java/win/baruna/blockmeter/ModConfig.java
+++ b/src/main/java/win/baruna/blockmeter/ModConfig.java
@@ -12,6 +12,7 @@ public class ModConfig implements ConfigData {
     public boolean deleteBoxesOnDisable = true;
     @ConfigEntry.Gui.Tooltip(count = 3)
     public boolean sendBoxes = true;
+    public boolean showBoxesWhenDisabled = false;
 
     @ConfigEntry.Gui.Excluded
     public boolean incrementColor = true;

--- a/src/main/java/win/baruna/blockmeter/gui/ModMenu.java
+++ b/src/main/java/win/baruna/blockmeter/gui/ModMenu.java
@@ -1,0 +1,15 @@
+package win.baruna.blockmeter.gui;
+
+import io.github.prospector.modmenu.api.ConfigScreenFactory;
+import io.github.prospector.modmenu.api.ModMenuApi;
+import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import win.baruna.blockmeter.ModConfig;
+
+public class ModMenu implements ModMenuApi {
+    @Override
+    public ConfigScreenFactory<?> getModConfigScreenFactory() {
+        return parent -> {
+            return AutoConfig.getConfigScreen(ModConfig.class, parent).get();
+        };
+    }
+}

--- a/src/main/java/win/baruna/blockmeter/gui/OptionsGui.java
+++ b/src/main/java/win/baruna/blockmeter/gui/OptionsGui.java
@@ -32,23 +32,23 @@ public class OptionsGui extends Screen {
                 this.addButton((AbstractButtonWidget) new ColorSelectButton(this.width / 2 - 44 + j * 22, this.height / 2 - 88 + i * 22, 20, 20, "", i * 4 + j));
             }
         }
-        this.addButton((AbstractButtonWidget) new ButtonWidget(this.width / 2 - BUTTONWIDTH/2, this.height / 2 + 10, BUTTONWIDTH, 20,
+        this.addButton((AbstractButtonWidget) new ButtonWidget(this.width / 2 - BUTTONWIDTH / 2, this.height / 2 + 10, BUTTONWIDTH, 20,
                 new TranslatableText("blockmeter.keepcolor", new Object[] {
                         new TranslatableText(ClientMeasureBox.incrementColor ? "options.off" : "options.on")
                 }), button -> {
                     ClientMeasureBox.incrementColor = !ClientMeasureBox.incrementColor;
                     MinecraftClient.getInstance().openScreen((Screen) new OptionsGui());
                 }));
-        this.addButton((AbstractButtonWidget) new ButtonWidget(this.width / 2 - BUTTONWIDTH/2, this.height / 2 + 32, BUTTONWIDTH, 20,
+        this.addButton((AbstractButtonWidget) new ButtonWidget(this.width / 2 - BUTTONWIDTH / 2, this.height / 2 + 32, BUTTONWIDTH, 20,
                 new TranslatableText("blockmeter.diagonal", new Object[] {
-                    new TranslatableText(ClientMeasureBox.innerDiagonal ? "options.on" : "options.off")
+                        new TranslatableText(ClientMeasureBox.innerDiagonal ? "options.on" : "options.off")
                 }), button -> {
                     ClientMeasureBox.innerDiagonal = !ClientMeasureBox.innerDiagonal;
                     MinecraftClient.getInstance().openScreen((Screen) null);
                 }));
-        this.addButton((AbstractButtonWidget) new ButtonWidget(this.width / 2 - BUTTONWIDTH/2, this.height / 2 + 54, BUTTONWIDTH, 20,
+        this.addButton((AbstractButtonWidget) new ButtonWidget(this.width / 2 - BUTTONWIDTH / 2, this.height / 2 + 54, BUTTONWIDTH, 20,
                 new TranslatableText("blockmeter.showothers", new Object[] {
-                    new TranslatableText( BlockMeterClient.getShowOtherUsers() ? "options.off" : "options.on")
+                        new TranslatableText(BlockMeterClient.getShowOtherUsers() ? "options.off" : "options.on")
                 }), button -> {
                     BlockMeterClient.setShowOtherUsers(!BlockMeterClient.getShowOtherUsers());
                     MinecraftClient.getInstance().openScreen((Screen) null);
@@ -77,10 +77,14 @@ public class OptionsGui extends Screen {
         ColorSelectButton(final int x, final int y, final int width, final int height, final String string, final int colorIndex) {
             super(x, y, width, height, new LiteralText(string), button -> {
                 ClientMeasureBox.selectColorIndex(colorIndex);
+
+                final ClientMeasureBox currentBox = BlockMeterClient.instance.currentBox();
+                if (currentBox != null)
+                    currentBox.setColor(DyeColor.byId(colorIndex));
                 MinecraftClient.getInstance().openScreen((Screen) null);
             });
             this.selected = false;
-            this.color = DyeColor.values()[colorIndex].getColorComponents();
+            this.color = DyeColor.byId(colorIndex).getColorComponents();
             this.x = x + 2;
             this.y = y + 2;
             this.width = width - 4;

--- a/src/main/java/win/baruna/blockmeter/gui/OptionsGui.java
+++ b/src/main/java/win/baruna/blockmeter/gui/OptionsGui.java
@@ -2,8 +2,6 @@ package win.baruna.blockmeter.gui;
 
 import com.mojang.blaze3d.platform.GlStateManager;
 
-import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
-import me.sargunvohra.mcmods.autoconfig1u.ConfigManager;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.AbstractButtonWidget;
@@ -30,9 +28,7 @@ public class OptionsGui extends Screen {
 
     @Override
     protected void init() {
-        // This is ugly I know, but I did not find something better
-        ConfigManager<ModConfig> confmgr = (ConfigManager<ModConfig>) AutoConfig.getConfigHolder(ModConfig.class);
-        ModConfig config = confmgr.getConfig();
+        ModConfig config = BlockMeterClient.confmgr.getConfig();
         for (int i = 0; i < 4; ++i) {
             for (int j = 0; j < 4; ++j) {
                 this.addButton((AbstractButtonWidget) new ColorSelectButton(this.width / 2 - 44 + j * 22, this.height / 2 - 88 + i * 22, 20, 20, "", i * 4 + j));
@@ -43,8 +39,10 @@ public class OptionsGui extends Screen {
                         new TranslatableText(config.incrementColor ? "options.off" : "options.on")
                 }), button -> {
                     config.incrementColor = !config.incrementColor;
-                    MinecraftClient.getInstance().openScreen((Screen) new OptionsGui());
-                    confmgr.save();
+                    MinecraftClient.getInstance().openScreen((Screen) null);
+                    // Todo find a way to increment to a new Color if a box was created while
+                    // incrementColor was disabled
+                    BlockMeterClient.confmgr.save();
                 }));
         this.addButton((AbstractButtonWidget) new ButtonWidget(this.width / 2 - BUTTONWIDTH / 2, this.height / 2 + 32, BUTTONWIDTH, 20,
                 new TranslatableText("blockmeter.diagonal", new Object[] {
@@ -52,7 +50,7 @@ public class OptionsGui extends Screen {
                 }), button -> {
                     config.innerDiagonal = !config.innerDiagonal;
                     MinecraftClient.getInstance().openScreen((Screen) null);
-                    confmgr.save();
+                    BlockMeterClient.confmgr.save();
                 }));
         this.addButton((AbstractButtonWidget) new ButtonWidget(this.width / 2 - BUTTONWIDTH / 2, this.height / 2 + 54, BUTTONWIDTH, 20,
                 new TranslatableText("blockmeter.showothers", new Object[] {
@@ -60,7 +58,7 @@ public class OptionsGui extends Screen {
                 }), button -> {
                     config.showOtherUsersBoxes = !config.showOtherUsersBoxes;
                     MinecraftClient.getInstance().openScreen((Screen) null);
-                    confmgr.save();
+                    BlockMeterClient.confmgr.save();
                 }));
     }
 
@@ -98,7 +96,7 @@ public class OptionsGui extends Screen {
             this.y = y + 2;
             this.width = width - 4;
             this.height = height - 4;
-            if (ClientMeasureBox.colorIndex == colorIndex) {
+            if (BlockMeterClient.confmgr.getConfig().colorIndex == colorIndex) {
                 this.setFocused(true);
                 this.selected = true;
             }

--- a/src/main/java/win/baruna/blockmeter/gui/OptionsGui.java
+++ b/src/main/java/win/baruna/blockmeter/gui/OptionsGui.java
@@ -2,6 +2,8 @@ package win.baruna.blockmeter.gui;
 
 import com.mojang.blaze3d.platform.GlStateManager;
 
+import me.sargunvohra.mcmods.autoconfig1u.AutoConfig;
+import me.sargunvohra.mcmods.autoconfig1u.ConfigManager;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.AbstractButtonWidget;
@@ -16,6 +18,7 @@ import net.minecraft.text.TranslatableText;
 import net.minecraft.util.DyeColor;
 import win.baruna.blockmeter.BlockMeterClient;
 import win.baruna.blockmeter.ClientMeasureBox;
+import win.baruna.blockmeter.ModConfig;
 
 public class OptionsGui extends Screen {
 
@@ -27,6 +30,9 @@ public class OptionsGui extends Screen {
 
     @Override
     protected void init() {
+        // This is ugly I know, but I did not find something better
+        ConfigManager<ModConfig> confmgr = (ConfigManager<ModConfig>) AutoConfig.getConfigHolder(ModConfig.class);
+        ModConfig config = confmgr.getConfig();
         for (int i = 0; i < 4; ++i) {
             for (int j = 0; j < 4; ++j) {
                 this.addButton((AbstractButtonWidget) new ColorSelectButton(this.width / 2 - 44 + j * 22, this.height / 2 - 88 + i * 22, 20, 20, "", i * 4 + j));
@@ -34,24 +40,27 @@ public class OptionsGui extends Screen {
         }
         this.addButton((AbstractButtonWidget) new ButtonWidget(this.width / 2 - BUTTONWIDTH / 2, this.height / 2 + 10, BUTTONWIDTH, 20,
                 new TranslatableText("blockmeter.keepcolor", new Object[] {
-                        new TranslatableText(ClientMeasureBox.incrementColor ? "options.off" : "options.on")
+                        new TranslatableText(config.incrementColor ? "options.off" : "options.on")
                 }), button -> {
-                    ClientMeasureBox.incrementColor = !ClientMeasureBox.incrementColor;
+                    config.incrementColor = !config.incrementColor;
                     MinecraftClient.getInstance().openScreen((Screen) new OptionsGui());
+                    confmgr.save();
                 }));
         this.addButton((AbstractButtonWidget) new ButtonWidget(this.width / 2 - BUTTONWIDTH / 2, this.height / 2 + 32, BUTTONWIDTH, 20,
                 new TranslatableText("blockmeter.diagonal", new Object[] {
-                        new TranslatableText(ClientMeasureBox.innerDiagonal ? "options.on" : "options.off")
+                        new TranslatableText(config.innerDiagonal ? "options.on" : "options.off")
                 }), button -> {
-                    ClientMeasureBox.innerDiagonal = !ClientMeasureBox.innerDiagonal;
+                    config.innerDiagonal = !config.innerDiagonal;
                     MinecraftClient.getInstance().openScreen((Screen) null);
+                    confmgr.save();
                 }));
         this.addButton((AbstractButtonWidget) new ButtonWidget(this.width / 2 - BUTTONWIDTH / 2, this.height / 2 + 54, BUTTONWIDTH, 20,
                 new TranslatableText("blockmeter.showothers", new Object[] {
-                        new TranslatableText(BlockMeterClient.getShowOtherUsers() ? "options.off" : "options.on")
+                        new TranslatableText(config.showOtherUsersBoxes ? "options.on" : "options.off")
                 }), button -> {
-                    BlockMeterClient.setShowOtherUsers(!BlockMeterClient.getShowOtherUsers());
+                    config.showOtherUsersBoxes = !config.showOtherUsersBoxes;
                     MinecraftClient.getInstance().openScreen((Screen) null);
+                    confmgr.save();
                 }));
     }
 

--- a/src/main/java/win/baruna/blockmeter/mixin/ClientPlayerConnectionMixin.java
+++ b/src/main/java/win/baruna/blockmeter/mixin/ClientPlayerConnectionMixin.java
@@ -6,6 +6,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.network.packet.s2c.play.DisconnectS2CPacket;
 import net.minecraft.network.packet.s2c.play.GameJoinS2CPacket;
 import win.baruna.blockmeter.BlockMeterClient;
 
@@ -17,8 +18,8 @@ public class ClientPlayerConnectionMixin {
         BlockMeterClient.instance.onConnected();
     }
 
-    @Inject(method = "onDisconnected", at = @At("HEAD"))
-    public void onDisconnectedFromServerEvent(CallbackInfo cbi) {
+    @Inject(method = "onDisconnect", at = @At("HEAD"))
+    public void onDisconnectedFromServerEvent(DisconnectS2CPacket packet, CallbackInfo cbi) {
         BlockMeterClient.instance.onDisconnected();
     }
 }

--- a/src/main/java/win/baruna/blockmeter/mixin/GameMixin.java
+++ b/src/main/java/win/baruna/blockmeter/mixin/GameMixin.java
@@ -16,6 +16,6 @@ public class GameMixin {
     @Inject(method = "<init>*", at = @At("RETURN"))
     private void onSessionStarted(final ClientWorld clientWorld_1, final ClientPlayerEntity clientPlayerEntity_1, final ClientPlayNetworkHandler clientPlayNetworkHandler_1,
             final CallbackInfo info) {
-        BlockMeterClient.instance.clear();
+        BlockMeterClient.instance.reset();
     }
 }

--- a/src/main/resources/assets/blockmeter/lang/de_de.json
+++ b/src/main/resources/assets/blockmeter/lang/de_de.json
@@ -14,5 +14,5 @@
     
     "text.autoconfig.blockmeter.title": "Blockmeter",
     "text.autoconfig.blockmeter.option.minimalLabelSize": "Minimalgröße für Boxbeschriftungen",
-    "text.autoconfig.blockmeter.option.deleteBoxesOnDisable": "Entferne Boxen beim ausschalten"
+    "text.autoconfig.blockmeter.option.deleteBoxesOnDisable": "Entferne Boxen beim deaktivieren"
 }

--- a/src/main/resources/assets/blockmeter/lang/de_de.json
+++ b/src/main/resources/assets/blockmeter/lang/de_de.json
@@ -5,8 +5,12 @@
     "blockmeter.toggle.on": "%s wird jetzt als Blockmeter verwendet!",
     "blockmeter.toggle.off": "Blockmeter ist abgeschaltet!",
     "blockmeter.clearlast": "Letzte Box gelöscht",
-    "category.blockmeter.key": "Blockmeter",
     "blockmeter.showothers": "Boxen anderer Spieler anzeigen: %s",
+    
+    "category.blockmeter.key": "Blockmeter",
+    
     "key.blockmeter.assign": "Blockmeter an/aus",
-    "key.blockmeter.menu": "Optionen zeigen"
+    "key.blockmeter.menu": "Optionen zeigen",
+
+    "text.autoconfig.blockmeter.option.consistentLabelSize": "Einheitliche Boxbeschriftungsgröße"
 }

--- a/src/main/resources/assets/blockmeter/lang/de_de.json
+++ b/src/main/resources/assets/blockmeter/lang/de_de.json
@@ -1,4 +1,5 @@
 {
+    "blockmeter.name": "Blockmeter",
     "blockmeter.keepcolor": "Immer aktuelle Farbe: %s",
     "blockmeter.diagonal": "Innere diagonale Linie: %s",
     "blockmeter.toggle.on": "%s wird jetzt als Blockmeter verwendet!",

--- a/src/main/resources/assets/blockmeter/lang/de_de.json
+++ b/src/main/resources/assets/blockmeter/lang/de_de.json
@@ -12,5 +12,5 @@
     "key.blockmeter.assign": "Blockmeter an/aus",
     "key.blockmeter.menu": "Optionen zeigen",
 
-    "text.autoconfig.blockmeter.option.consistentLabelSize": "Einheitliche Boxbeschriftungsgröße"
+    "text.autoconfig.blockmeter.option.minimalLabelSize": "Minimalgröße für Boxbeschriftungen"
 }

--- a/src/main/resources/assets/blockmeter/lang/de_de.json
+++ b/src/main/resources/assets/blockmeter/lang/de_de.json
@@ -1,5 +1,4 @@
 {
-    "blockmeter.name": "Blockmeter",
     "blockmeter.keepcolor": "Immer aktuelle Farbe: %s",
     "blockmeter.diagonal": "Innere diagonale Linie: %s",
     "blockmeter.toggle.on": "%s wird jetzt als Blockmeter verwendet!",
@@ -12,7 +11,8 @@
     
     "key.blockmeter.assign": "Blockmeter an/aus",
     "key.blockmeter.menu": "Optionen zeigen",
-
+    
+    "text.autoconfig.blockmeter.title": "Blockmeter",
     "text.autoconfig.blockmeter.option.minimalLabelSize": "Minimalgröße für Boxbeschriftungen",
     "text.autoconfig.blockmeter.option.deleteBoxesOnDisable": "Entferne Boxen beim ausschalten"
 }

--- a/src/main/resources/assets/blockmeter/lang/de_de.json
+++ b/src/main/resources/assets/blockmeter/lang/de_de.json
@@ -5,6 +5,7 @@
     "blockmeter.toggle.on": "%s wird jetzt als Blockmeter verwendet!",
     "blockmeter.toggle.off": "Blockmeter ist abgeschaltet!",
     "blockmeter.clearlast": "Letzte Box gelöscht",
+    "blockmeter.clearall": "Alle Boxen gelöscht",
     "blockmeter.showothers": "Boxen anderer Spieler anzeigen: %s",
     
     "category.blockmeter.key": "Blockmeter",
@@ -12,5 +13,6 @@
     "key.blockmeter.assign": "Blockmeter an/aus",
     "key.blockmeter.menu": "Optionen zeigen",
 
-    "text.autoconfig.blockmeter.option.minimalLabelSize": "Minimalgröße für Boxbeschriftungen"
+    "text.autoconfig.blockmeter.option.minimalLabelSize": "Minimalgröße für Boxbeschriftungen",
+    "text.autoconfig.blockmeter.option.deleteBoxesOnDisable": "Entferne Boxen beim ausschalten"
 }

--- a/src/main/resources/assets/blockmeter/lang/en_us.json
+++ b/src/main/resources/assets/blockmeter/lang/en_us.json
@@ -5,8 +5,12 @@
     "blockmeter.toggle.on": "%s is now used as your block meter!",
     "blockmeter.toggle.off": "Block Meter is now turned off!",
     "blockmeter.clearlast": "Last box cleared",
-    "category.blockmeter.key": "Block Meter",
     "blockmeter.showothers": "Show other user's boxses: %s",
+
+    "category.blockmeter.key": "Block Meter",
+
     "key.blockmeter.assign": "Toggle Block Meter",
-    "key.blockmeter.menu": "Show Options"
+    "key.blockmeter.menu": "Show Options",
+
+    "text.autoconfig.blockmeter.option.consistentLabelSize": "Consistant box label size"
 }

--- a/src/main/resources/assets/blockmeter/lang/en_us.json
+++ b/src/main/resources/assets/blockmeter/lang/en_us.json
@@ -13,6 +13,18 @@
     "key.blockmeter.menu": "Show Options",
 
     "text.autoconfig.blockmeter.title": "Block Meter",
+
     "text.autoconfig.blockmeter.option.minimalLabelSize": "Minimal Box Label Size",
-    "text.autoconfig.blockmeter.option.deleteBoxesOnDisable": "Remove Boxes on Disable"
+    "text.autoconfig.blockmeter.option.minimalLabelSize.@Tooltip[0]": "After 10 blocks, the labels keep their",
+    "text.autoconfig.blockmeter.option.minimalLabelSize.@Tooltip[1]": "size to improve long distance readability",
+
+    "text.autoconfig.blockmeter.option.deleteBoxesOnDisable": "Remove Boxes on Disable",
+    "text.autoconfig.blockmeter.option.deleteBoxesOnDisable.@Tooltip[0]": "Removes measurring boxes when hitting",
+    "text.autoconfig.blockmeter.option.deleteBoxesOnDisable.@Tooltip[1]": "the keybind to disable the blockmeter",
+    
+    "text.autoconfig.blockmeter.option.sendBoxes": "Sends Boxes to other users on capable Servers",
+    "text.autoconfig.blockmeter.option.sendBoxes.@Tooltip[0]": "Boxes can be hidden via in-game options", 
+    "text.autoconfig.blockmeter.option.sendBoxes.@Tooltip[1]": "The server requires the Block Meter mod either",
+    "text.autoconfig.blockmeter.option.sendBoxes.@Tooltip[2]": "as plugin (Bukkit) or mod (Fabric) installed."
+
 }

--- a/src/main/resources/assets/blockmeter/lang/en_us.json
+++ b/src/main/resources/assets/blockmeter/lang/en_us.json
@@ -5,6 +5,7 @@
     "blockmeter.toggle.on": "%s is now used as your block meter!",
     "blockmeter.toggle.off": "Block Meter is now turned off!",
     "blockmeter.clearlast": "Last box cleared",
+    "blockmeter.clearall": "All boxes cleared",
     "blockmeter.showothers": "Show other user's boxses: %s",
 
     "category.blockmeter.key": "Block Meter",
@@ -12,5 +13,6 @@
     "key.blockmeter.assign": "Toggle Block Meter",
     "key.blockmeter.menu": "Show Options",
 
-    "text.autoconfig.blockmeter.option.minimalLabelSize": "Minimal box label size"
+    "text.autoconfig.blockmeter.option.minimalLabelSize": "Minimal Box Label Size",
+    "text.autoconfig.blockmeter.option.deleteBoxesOnDisable": "Remove Boxes on Disable"
 }

--- a/src/main/resources/assets/blockmeter/lang/en_us.json
+++ b/src/main/resources/assets/blockmeter/lang/en_us.json
@@ -25,6 +25,8 @@
     "text.autoconfig.blockmeter.option.sendBoxes": "Sends Boxes to other users on capable Servers",
     "text.autoconfig.blockmeter.option.sendBoxes.@Tooltip[0]": "Boxes can be hidden via in-game options", 
     "text.autoconfig.blockmeter.option.sendBoxes.@Tooltip[1]": "The server requires the Block Meter mod either",
-    "text.autoconfig.blockmeter.option.sendBoxes.@Tooltip[2]": "as plugin (Bukkit) or mod (Fabric) installed."
+    "text.autoconfig.blockmeter.option.sendBoxes.@Tooltip[2]": "as plugin (Bukkit) or mod (Fabric) installed.",
+    
+    "text.autoconfig.blockmeter.option.showBoxesWhenDisabled": "Show Boxes when Block Meter is disabled"
 
 }

--- a/src/main/resources/assets/blockmeter/lang/en_us.json
+++ b/src/main/resources/assets/blockmeter/lang/en_us.json
@@ -12,5 +12,5 @@
     "key.blockmeter.assign": "Toggle Block Meter",
     "key.blockmeter.menu": "Show Options",
 
-    "text.autoconfig.blockmeter.option.consistentLabelSize": "Consistant box label size"
+    "text.autoconfig.blockmeter.option.minimalLabelSize": "Minimal box label size"
 }

--- a/src/main/resources/assets/blockmeter/lang/en_us.json
+++ b/src/main/resources/assets/blockmeter/lang/en_us.json
@@ -1,5 +1,4 @@
 {
-    "blockmeter.name": "Block Meter",
     "blockmeter.keepcolor": "Always Use Current Color: %s",
     "blockmeter.diagonal": "Inner Diagonal Line: %s",
     "blockmeter.toggle.on": "%s is now used as your block meter!",
@@ -13,6 +12,7 @@
     "key.blockmeter.assign": "Toggle Block Meter",
     "key.blockmeter.menu": "Show Options",
 
+    "text.autoconfig.blockmeter.title": "Block Meter",
     "text.autoconfig.blockmeter.option.minimalLabelSize": "Minimal Box Label Size",
     "text.autoconfig.blockmeter.option.deleteBoxesOnDisable": "Remove Boxes on Disable"
 }

--- a/src/main/resources/assets/blockmeter/lang/en_us.json
+++ b/src/main/resources/assets/blockmeter/lang/en_us.json
@@ -1,4 +1,5 @@
 {
+    "blockmeter.name": "Block Meter",
     "blockmeter.keepcolor": "Always Use Current Color: %s",
     "blockmeter.diagonal": "Inner Diagonal Line: %s",
     "blockmeter.toggle.on": "%s is now used as your block meter!",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -5,7 +5,8 @@
   "environment": "*",    
   "entrypoints": {
     "client": [ "win.baruna.blockmeter.BlockMeterClient" ],
-    "main": [ "win.baruna.blockmeter.BlockMeterServer" ]
+    "main": [ "win.baruna.blockmeter.BlockMeterServer" ],
+    "modmenu": ["win.baruna.blockmeter.gui.ModMenu"]
   },
   "custom": {
         "xxxmodmenu:clientsideOnly": true,
@@ -28,7 +29,7 @@
   "name": "Block Meter",
   "description": "A simple mod to measure your blocks!",
   "icon": "pack.png",
-  "authors": [ "MadeOke", "Giselbaer" ],
+  "authors": [ "MadeOke", "Giselbaer", "ModProg" ],
 
   "contact": {
     "homepage": "https://www.curseforge.com/minecraft/mc-mods/blockmeterfabric",


### PR DESCRIPTION
## Includes a breaking Change
This is based on #3 

## Fixing onDisconnect
The right Mixin is `onDisconnect` instead of `onDisconnected`

## Fixing Multiplayer and Dimension
_**Breaking Change**_
Changed the type of `MeasureBox.dimension` to `Identifier` to fix both the Fabric Server (`readString` is no longer supported) and the Dimension differentiation as `getSuffix()` only returns an empty string.
As Compatibility was already broken, `MeasureBox` now submits two new values `mode` and `orientation` which should be sufficient for all shapes that were planned to be implemented.

##  Added new Settings
![image](https://user-images.githubusercontent.com/11978847/88980812-c512fb80-d2c4-11ea-986e-c08144b193e6.png)
It is now possible to deactivate sending boxes to other users.
It is also possible to keep the boxes visible when disabling Block Meter
For possibly unclear settings there are tool tips now.

## Quickmenu is now persistent
It is stored in the Config.
